### PR TITLE
Story 1 create question revisions

### DIFF
--- a/app/models/answer_choice.rb
+++ b/app/models/answer_choice.rb
@@ -1,3 +1,3 @@
 class AnswerChoice < ApplicationRecord
-  belongs_to :question
+  belongs_to :question, required: false
 end

--- a/app/models/answer_choice.rb
+++ b/app/models/answer_choice.rb
@@ -1,3 +1,4 @@
 class AnswerChoice < ApplicationRecord
   belongs_to :question, required: false
+  belongs_to :question_revision, required: false
 end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,10 +1,6 @@
 class Question < ApplicationRecord
   has_many :answer_choices
 
-  after_create do
-    ["A", "B", "C", "D"].each do |letter|
-      answer_choices.create letter: letter
-    end
   end
 
   def answer

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,7 +1,10 @@
 class Question < ApplicationRecord
   has_many :answer_choices
+  has_many :question_revisions
   accepts_nested_attributes_for :answer_choices
 
+  def update_attributes *attrs
+    question_revisions.create attrs
   end
 
   def answer

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -1,5 +1,6 @@
 class Question < ApplicationRecord
   has_many :answer_choices
+  accepts_nested_attributes_for :answer_choices
 
   end
 

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -4,7 +4,7 @@ class Question < ApplicationRecord
   accepts_nested_attributes_for :answer_choices
 
   def update_attributes *attrs
-    question_revisions.create attrs
+    question_revisions.create(attrs).first
   end
 
   def answer

--- a/app/models/question_revision.rb
+++ b/app/models/question_revision.rb
@@ -2,4 +2,8 @@ class QuestionRevision < ApplicationRecord
   has_many :answer_choices, dependent: :destroy
   belongs_to :question
   accepts_nested_attributes_for :answer_choices
+
+  def answer
+    answer_choices.find_by_answer true
+  end
 end

--- a/app/models/question_revision.rb
+++ b/app/models/question_revision.rb
@@ -1,0 +1,5 @@
+class QuestionRevision < ApplicationRecord
+  has_many :answer_choices, dependent: :destroy
+  belongs_to :question
+  accepts_nested_attributes_for :answer_choices
+end

--- a/db/migrate/20170412183848_create_question_revisions.rb
+++ b/db/migrate/20170412183848_create_question_revisions.rb
@@ -1,0 +1,10 @@
+class CreateQuestionRevisions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :question_revisions do |t|
+      t.integer :question_id
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20170412184938_add_question_revision_id_to_answer_choices.rb
+++ b/db/migrate/20170412184938_add_question_revision_id_to_answer_choices.rb
@@ -1,0 +1,5 @@
+class AddQuestionRevisionIdToAnswerChoices < ActiveRecord::Migration[5.0]
+  def change
+    add_column :answer_choices, :question_revision_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412182852) do
+ActiveRecord::Schema.define(version: 20170412184938) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,9 +19,17 @@ ActiveRecord::Schema.define(version: 20170412182852) do
     t.integer  "question_id"
     t.string   "name"
     t.string   "letter"
-    t.boolean  "answer",      default: false
-    t.datetime "created_at",                  null: false
-    t.datetime "updated_at",                  null: false
+    t.boolean  "answer",               default: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.integer  "question_revision_id"
+  end
+
+  create_table "question_revisions", force: :cascade do |t|
+    t.integer  "question_id"
+    t.string   "name"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
   end
 
   create_table "questions", force: :cascade do |t|

--- a/spec/models/question_revision_spec.rb
+++ b/spec/models/question_revision_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe QuestionRevision, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,5 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe Question, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:question) { Question.create name: 'First question?' }
+
+  describe '#update_attributes' do
+    context 'When a Question is updated' do
+      it 'creates a QuestionRevision' do
+        updated_question = question.update_attributes(name: 'Second question?')
+        expect(updated_question).to be_a QuestionRevision
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Synopsis
As an editor, I should be able to create a new revision for a question

Based on a report from the data analytics team, I have identified a question that seems to trip up too
many people. I need to create a new revision with better (less confusing) answer choices. Editing a
question should create a new revision, since we don’t want to impact the existing question and its
associations.

# Included
* Created `QuestionRevision` (`belongs_to :question` `has_many :answer_choices`)
* Overwrote `Question#update_attributes` to create a `QuestionRevision` with the passed in attributes
* Removed `after_create` callback from `Question` that automatically created `AnswerChoices` and replaced it with `accepts_nested_attributes_for :answer_choices`