### PR TITLE
Story 2 create answer choice suggestions

### DIFF
--- a/app/models/answer_choice.rb
+++ b/app/models/answer_choice.rb
@@ -2,4 +2,8 @@ class AnswerChoice < ApplicationRecord
   belongs_to :question, required: false
   belongs_to :question_revision, required: false
   has_many :suggestions, class_name: "AnswerChoiceSuggestion"
+
+  def create_suggestion name
+    suggestions.create name: name
+  end
 end

--- a/app/models/answer_choice.rb
+++ b/app/models/answer_choice.rb
@@ -1,4 +1,5 @@
 class AnswerChoice < ApplicationRecord
   belongs_to :question, required: false
   belongs_to :question_revision, required: false
+  has_many :suggestions, class_name: "AnswerChoiceSuggestion"
 end

--- a/app/models/answer_choice_suggestion.rb
+++ b/app/models/answer_choice_suggestion.rb
@@ -1,0 +1,3 @@
+class AnswerChoiceSuggestion < ApplicationRecord
+  belongs_to :answer
+end

--- a/db/migrate/20170412192139_create_answer_choice_suggestions.rb
+++ b/db/migrate/20170412192139_create_answer_choice_suggestions.rb
@@ -1,0 +1,10 @@
+class CreateAnswerChoiceSuggestions < ActiveRecord::Migration[5.0]
+  def change
+    create_table :answer_choice_suggestions do |t|
+      t.integer :answer_choice_id
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170412184938) do
+ActiveRecord::Schema.define(version: 20170412192139) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "answer_choice_suggestions", force: :cascade do |t|
+    t.integer  "answer_choice_id"
+    t.string   "name"
+    t.datetime "created_at",       null: false
+    t.datetime "updated_at",       null: false
+  end
 
   create_table "answer_choices", force: :cascade do |t|
     t.integer  "question_id"

--- a/spec/models/answer_choice_spec.rb
+++ b/spec/models/answer_choice_spec.rb
@@ -1,5 +1,12 @@
 require 'rails_helper'
 
 RSpec.describe AnswerChoice, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  subject(:answer_choice) { AnswerChoice.create name: 'Blue' }
+
+  describe '#create_suggestion' do
+    it 'creates a new AnswerChoiceSuggestion' do
+      create_suggestion = answer_choice.create_suggestion 'Green'
+      expect(create_suggestion).to be_a AnswerChoiceSuggestion
+    end
+  end
 end


### PR DESCRIPTION
# Synopsis
As an editor, I should be able to create a new revision for a question

Based on a report from the data analytics team, I have identified a question that seems to trip up too
many people. I need to create a new revision with better (less confusing) answer choices. Editing a
question should create a new revision, since we don’t want to impact the existing question and its
associations.

# Included
* Created `AnswerChoiceSuggestion` (`belongs_to :answer_choice`)
* Updated `AnswerChoice` to have many `AnswerChoiceSuggestion`'s
* Added `AnswerChoice#create_suggestion` to create an associated `AnswerChoiceSuggestion`