### PR TITLE
Story 3 make suggestions viewable

### DIFF
--- a/app/models/answer_choice_suggestion.rb
+++ b/app/models/answer_choice_suggestion.rb
@@ -1,3 +1,3 @@
 class AnswerChoiceSuggestion < ApplicationRecord
-  belongs_to :answer
+  belongs_to :answer_choice
 end

--- a/app/models/question_revision.rb
+++ b/app/models/question_revision.rb
@@ -6,4 +6,12 @@ class QuestionRevision < ApplicationRecord
   def answer
     answer_choices.find_by_answer true
   end
+
+  def answer_choices_and_suggestions
+    answer_choices_and_suggestions = {}
+    answer_choices.each do |answer_choice|
+      answer_choices_and_suggestions[answer_choice.name] = answer_choice.suggestions.map &:name
+    end
+    answer_choices_and_suggestions
+  end
 end


### PR DESCRIPTION
# Synopsis
Store 3: As an editor, I should be able to see all the suggested alternatives

In finalizing a question for approval, an editor should be able to view all the suggestions put forth by
multiple reviewers. There will always be four choices, but some choices may have multiple suggestions.

# Included
* Added `QuestionRevision#answer_choices_and_suggestions` to produce a hash of answer choices and their suggestions